### PR TITLE
Package the license and readme

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.rst
 include LICENSE.txt


### PR DESCRIPTION
Makes sure the license file and Readme are packaged in any `sdist`s made.