### PR TITLE
Test hello

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,18 @@
 # MacOS
-.DS_Store
+.DS_Store/
 
 # PyCharm IDE
-.idea
+/.idea/
 
 # Compiled python modules.
-*.pyc
+*.pyc/
 
 # Setuptools distribution folder.
 /dist/
 
 # Python egg metadata, regenerated from source files by setuptools.
-/*.egg-info
+/*.egg-info/
 
 # pytest
-.cache
+/.cache/
+/.eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,11 @@
 # Compiled python modules.
 *.pyc/
 
-# Setuptools distribution folder.
+# Setuptools distribution folder (result of pypi upload procedure)
 /dist/
+
+# output of python setup.py install
+/build/
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
+
+# pytest
+.cache

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,19 @@
 README
 ======
 pyjc is an educational deep learning framework.
+
+
+Testing
+=======
+
+To test, do this at the project root directory:
+
+::
+
+    $ python setup.py test
+
+or
+
+::
+
+    $ pytest

--- a/pyjc/tests/test_helloworld.py
+++ b/pyjc/tests/test_helloworld.py
@@ -1,0 +1,6 @@
+import pyjc
+
+
+def test_helloworld():
+    assert isinstance(pyjc.helloworld(), str)
+    assert pyjc.helloworld() == "Hello World!"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     keywords=['deep learning', 'education', 'scientific computing', 'artificial intelligence'],
-    python_requires='>=3.6',
+    python_requires='==3.6',
     setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    tests_require=['pytest>=3.2.2'],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from setuptools import setup
 setup(
     name='pyjc',
     version='0.1.0',
+    packages=['pyjc'],
     description='An educational deep learning framework',
     url='http://github.com/Atlas7/pyjc',
     download_url='https://github.com/Atlas7/pyjc/archive/v0.1.0.tar.gz',
     author='Johnny Chan',
     author_email='johnnychan0302@gmail.com',
     license='MIT',
-    packages=['pyjc'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -21,4 +21,6 @@ setup(
     ],
     keywords=['deep learning', 'education', 'scientific computing', 'artificial intelligence'],
     python_requires='>=3.6',
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
 )

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "3.6"
+install:
+  - python setup.py --quiet install
+script: pytest

--- a/travis.yml
+++ b/travis.yml
@@ -5,4 +5,4 @@ python:
 install:
   - python setup.py --quiet install
 script:
-  - python setup.py test
+  - pytest

--- a/travis.yml
+++ b/travis.yml
@@ -1,6 +1,8 @@
-language: python
+language:
+  - python
 python:
   - "3.6"
 install:
   - python setup.py --quiet install
-script: pytest
+script:
+  - python setup.py test


### PR DESCRIPTION
Incorporate pytest and Travis CI for testing. This is more of a skeleton stub. Locally we can now do `pytest` to test against all the scripts in the `tests` sub directories. Also, an alternative `python setup.py test` will output more test logging at /pyjc.egg-info/`.