### PR TITLE
update version to 0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import setup
 
 setup(
     name='pyjc',
-    version='0.1.1',
+    version='0.1.2',
     packages=['pyjc'],
     description='An educational deep learning framework',
     url='http://github.com/Atlas7/pyjc',
-    download_url='https://github.com/Atlas7/pyjc/archive/v0.1.1.tar.gz',
+    download_url='https://github.com/Atlas7/pyjc/archive/v0.1.2.tar.gz',
     author='Johnny Chan',
     author_email='johnnychan0302@gmail.com',
     license='MIT',


### PR DESCRIPTION
The PyPi package in version 0.1.1 was deleted as a result of an experiment. It turns out I cannot re-upload that version. I have to update the version number. Hence this `0.1.2`. It's pretty much the same thing as `0.1.1` under a higher version number.